### PR TITLE
[REFACTOR] Total Modifiers in Active Effects, Global Effects and Modifiers Correctly Display the Total of Modificators

### DIFF
--- a/module/TheWitcherTRPG.js
+++ b/module/TheWitcherTRPG.js
@@ -305,3 +305,8 @@ Handlebars.registerHelper('includes', function (csv, substr) {
         .map(v => v.trim())
         .includes(substr);
 });
+
+Handlebars.registerHelper('formatModLabel', function (statCurrent, statMax, statTotalModifiers) {
+    let calc = (statCurrent - statMax) + statTotalModifiers
+    return calc
+  });

--- a/module/TheWitcherTRPG.js
+++ b/module/TheWitcherTRPG.js
@@ -306,7 +306,7 @@ Handlebars.registerHelper('includes', function (csv, substr) {
         .includes(substr);
 });
 
-Handlebars.registerHelper('formatModLabel', function (statCurrent, statMax, statTotalModifiers) {
-    let calc = (statCurrent - statMax) + statTotalModifiers
+Handlebars.registerHelper('formatModLabel', function (statCurrent, statMax) {
+    let calc = statCurrent - statMax
     return calc
   });

--- a/module/actor/sheets/mixins/statMixin.js
+++ b/module/actor/sheets/mixins/statMixin.js
@@ -191,7 +191,9 @@ export let statMixin = {
     calc_total_stats(context) {
         let totalStats = 0;
         for (let element in context.system.stats) {
-            totalStats += context.system.stats[element].max;
+            if (element !== 'toxicity') {
+                totalStats += context.system.stats[element].max;
+            }
         }
         return totalStats;
     },

--- a/module/actor/witcherActor.js
+++ b/module/actor/witcherActor.js
@@ -32,16 +32,16 @@ export default class WitcherActor extends Actor {
         const baseMax = Math.floor((stats.body.max + stats.will.max) / 2);
         const meleeBonus = Math.ceil((stats.body.current - 6) / 2) * 2;
 
-        let intTotalModifiers = this.getAllModifiers('int').totalModifiers;
-        let refTotalModifiers = this.getAllModifiers('ref').totalModifiers;
-        let dexTotalModifiers = this.getAllModifiers('dex').totalModifiers;
-        let bodyTotalModifiers = this.getAllModifiers('body').totalModifiers;
-        let spdTotalModifiers = this.getAllModifiers('spd').totalModifiers;
-        let empTotalModifiers = this.getAllModifiers('emp').totalModifiers;
-        let craTotalModifiers = this.getAllModifiers('cra').totalModifiers;
-        let willTotalModifiers = this.getAllModifiers('will').totalModifiers;
-        let luckTotalModifiers = this.getAllModifiers('luck').totalModifiers;
-        let toxTotalModifiers = this.getAllModifiers('toxicity').totalModifiers;
+        let intTotalModifiers = this.getAllModifiers('int').totalModifiers + stats.int.totalModifiers;
+        let refTotalModifiers = this.getAllModifiers('ref').totalModifiers + stats.ref.totalModifiers;
+        let dexTotalModifiers = this.getAllModifiers('dex').totalModifiers + stats.dex.totalModifiers;
+        let bodyTotalModifiers = this.getAllModifiers('body').totalModifiers + stats.body.totalModifiers;
+        let spdTotalModifiers = this.getAllModifiers('spd').totalModifiers + stats.spd.totalModifiers;
+        let empTotalModifiers = this.getAllModifiers('emp').totalModifiers + stats.emp.totalModifiers;
+        let craTotalModifiers = this.getAllModifiers('cra').totalModifiers + stats.cra.totalModifiers;
+        let willTotalModifiers = this.getAllModifiers('will').totalModifiers + stats.will.totalModifiers;
+        let luckTotalModifiers = this.getAllModifiers('luck').totalModifiers + stats.luck.totalModifiers;
+        let toxTotalModifiers = this.getAllModifiers('toxicity').totalModifiers + stats.toxicity.totalModifiers;
         let intDivider = this.getAllModifiers('int').totalDivider;
         let refDivider = this.getAllModifiers('ref').totalDivider;
         let dexDivider = this.getAllModifiers('dex').totalDivider;
@@ -164,16 +164,6 @@ export default class WitcherActor extends Actor {
             'system.stats.luck.current': curLuck,
             'system.stats.toxicity.max': curTox,
 
-            'system.stats.int.totalModifiers': intTotalModifiers,
-            'system.stats.ref.totalModifiers': refTotalModifiers,
-            'system.stats.dex.totalModifiers': dexTotalModifiers,
-            'system.stats.body.totalModifiers': bodyTotalModifiers,
-            'system.stats.spd.totalModifiers': spdTotalModifiers,
-            'system.stats.emp.totalModifiers': empTotalModifiers,
-            'system.stats.cra.totalModifiers': craTotalModifiers,
-            'system.stats.will.totalModifiers': willTotalModifiers,
-            'system.stats.luck.totalModifiers': luckTotalModifiers,
-
             'system.derivedStats.hp.max': curHp,
             'system.derivedStats.hp.unmodifiedMax': unmodifiedMaxHp,
             'system.derivedStats.sta.max': curSta,
@@ -183,27 +173,21 @@ export default class WitcherActor extends Actor {
 
             'system.coreStats.stun.current': Math.floor((Math.clamp(base, 1, 10) + stunTotalModifiers) / stunDivider),
             'system.coreStats.stun.max': Math.clamp(baseMax, 1, 10),
-            'system.coreStats.stun.totalModifiers': stunTotalModifiers,
 
             'system.coreStats.enc.current': Math.floor((stats.body.current * 10 + encTotalModifiers) / encDivider),
             'system.coreStats.enc.max': stats.body.current * 10,
-            'system.coreStats.enc.totalModifiers': encTotalModifiers,
 
             'system.coreStats.run.current': Math.floor((stats.spd.current * 3 + runTotalModifiers) / runDivider),
             'system.coreStats.run.max': stats.spd.current * 3,
-            'system.coreStats.run.totalModifiers': runTotalModifiers,
 
             'system.coreStats.leap.current': Math.floor((stats.spd.current * 3) / 5 + leapTotalModifiers) / leapDivider,
             'system.coreStats.leap.max': Math.floor((stats.spd.max * 3) / 5),
-            'system.coreStats.leap.totalModifiers': leapTotalModifiers,
 
             'system.coreStats.rec.current': Math.floor((base + recTotalModifiers) / recDivider),
             'system.coreStats.rec.max': baseMax,
-            'system.coreStats.rec.totalModifiers': recTotalModifiers,
 
             'system.coreStats.woundTreshold.current': Math.floor((baseMax + wtTotalModifiers) / wtDivider),
             'system.coreStats.woundTreshold.max': baseMax,
-            'system.coreStats.woundTreshold.totalModifiers': wtTotalModifiers,
 
             'system.attackStats.meleeBonus': meleeBonus,
             'system.attackStats.punch.value': `1d6+${meleeBonus}`,

--- a/templates/partials/character-header.hbs
+++ b/templates/partials/character-header.hbs
@@ -90,11 +90,11 @@
 								<div class='flex stat-info'>
 									<a class='char-stat-button stat-roll'>{{localize details.label}} {{details.current}}</a>
 									{{#if (gt details.current details.max)}}
-										<h4 class='header-stat stat-mod stat-mod-plus'>{{formatModLabel details.current details.max details.totalModifiers}}</h4>
+										<h4 class='header-stat stat-mod stat-mod-plus'>{{formatModLabel details.current details.max}}</h4>
 									{{else if (eq details.current details.max)}}
-										<h4 class='header-stat stat-mod stat-mod-zero'>{{formatModLabel details.current details.max details.totalModifiers}}</h4>
+										<h4 class='header-stat stat-mod stat-mod-zero'>{{formatModLabel details.current details.max}}</h4>
 									{{else}}
-										<h4 class='header-stat stat-mod stat-mod-minus'>{{formatModLabel details.current details.max details.totalModifiers}}</h4>
+										<h4 class='header-stat stat-mod stat-mod-minus'>{{formatModLabel details.current details.max}}</h4>
 									{{/if}}
 									<input class='header-stat stat-max' name='system.stats.{{stat}}.max' type='number' value='{{details.max}}' placeholder='0' data-dtype='Number' />
 

--- a/templates/partials/character-header.hbs
+++ b/templates/partials/character-header.hbs
@@ -89,12 +89,12 @@
 							<div>
 								<div class='flex stat-info'>
 									<a class='char-stat-button stat-roll'>{{localize details.label}} {{details.current}}</a>
-									{{#if (gt details.totalModifiers 0)}}
-										<h4 class='header-stat stat-mod stat-mod-plus'>{{details.totalModifiers}}</h4>
-									{{else if (eq details.totalModifiers 0)}}
-										<h4 class='header-stat stat-mod stat-mod-zero'>{{details.totalModifiers}}</h4>
+									{{#if (gt details.current details.max)}}
+										<h4 class='header-stat stat-mod stat-mod-plus'>{{formatModLabel details.current details.max details.totalModifiers}}</h4>
+									{{else if (eq details.current details.max)}}
+										<h4 class='header-stat stat-mod stat-mod-zero'>{{formatModLabel details.current details.max details.totalModifiers}}</h4>
 									{{else}}
-										<h4 class='header-stat stat-mod stat-mod-minus'>{{details.totalModifiers}}</h4>
+										<h4 class='header-stat stat-mod stat-mod-minus'>{{formatModLabel details.current details.max details.totalModifiers}}</h4>
 									{{/if}}
 									<input class='header-stat stat-max' name='system.stats.{{stat}}.max' type='number' value='{{details.max}}' placeholder='0' data-dtype='Number' />
 


### PR DESCRIPTION
The Mod column will now display the total number of mods, if they exist. Due to how the current status system works, I had to create a Handlebars helper to calculate and display the values correctly in the column. Additionally, mods will follow the rule of halving the Statistic when the Actor's life falls below the Wound Threshold. And fixing toxicity being summed in total Stats

| Life Below Wound Threshold| Active Effects, Modifier, Global Modifier |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b2a8b208-da1b-4acf-b3fa-6943dd19206c)| ![image](https://github.com/user-attachments/assets/036b694f-4c27-497c-9393-0190dee1b4ea)|