### PR TITLE
Fix int-based custom skills

### DIFF
--- a/templates/partials/character/tab-skills.hbs
+++ b/templates/partials/character/tab-skills.hbs
@@ -9,8 +9,8 @@
                     {{#each system.skills.int as |skill name|}}
                         {{> "systems/TheWitcherTRPG/templates/partials/character/skill-display.hbs" skill=skill name=name stat="int"}}
                     {{/each}}
-                    {{#each system.customSkills.int as |skill name|}}
-                        {{> "systems/TheWitcherTRPG/templates/partials/character/skill-display.hbs" skill=skill name=name stat="int"}}
+                    {{#each customSkills.int}}
+                        {{> "systems/TheWitcherTRPG/templates/partials/character/custom-skill-display.hbs"}}
                     {{/each}}
                 </table>
             </details>


### PR DESCRIPTION
Int-based custom skills not displaying due to incorrect data path. Changing it to be the same as the other custom skills in this template