### PR TITLE
Ability templates not working

### DIFF
--- a/module/item/ability-template.js
+++ b/module/item/ability-template.js
@@ -156,7 +156,7 @@ export default class AbilityTemplate extends MeasuredTemplate {
         if (now - this.#moveTime <= 20) return;
         const center = event.data.getLocalPosition(this.layer);
         const interval = canvas.grid.type === CONST.GRID_TYPES.GRIDLESS ? 0 : 2;
-        const snapped = canvas.grid.getSnappedPoint(center, interval);
+        const snapped = canvas.grid.getSnappedPoint(center, {mode: interval});
         this.document.updateSource({ x: snapped.x, y: snapped.y });
         this.refresh();
         this.#moveTime = now;
@@ -187,7 +187,7 @@ export default class AbilityTemplate extends MeasuredTemplate {
     async _onConfirmPlacement(event) {
         await this._finishPlacement(event);
         const interval = canvas.grid.type === CONST.GRID_TYPES.GRIDLESS ? 0 : 2;
-        const destination = canvas.grid.getSnappedPoint(this.document, interval);
+        const destination = canvas.grid.getSnappedPoint(this.document, {mode: interval});
         this.document.updateSource(destination);
         this.#events.resolve(canvas.scene.createEmbeddedDocuments('MeasuredTemplate', [this.document.toObject()]));
     }


### PR DESCRIPTION
**Describe the bug**
Casting any spell with an ability template does not display the 'Confirm Placement' template on the scene

**To Reproduce**
Try to cast any spell with an ability template

**Expected behavior**
Casting a spell would display the 'Confirm Placement' template and allow the user to choose the location

**Screenshots**
https://github.com/user-attachments/assets/10e32ae3-ecae-4933-8cda-a6fafa1815d0


**Versions**
- Foundry v12.330
- System v12.14.0

**Stactrace**
```js
ability-template.js:160 Uncaught TypeError: Cannot read properties of undefined (reading 'x')
[Detected 1 package: system:TheWitcherTRPG(AUTOMATICALLY REPLACED BY GITHUB WORKFLOW ACTION)]
    at AbilityTemplate._onMovePlacement (ability-template.js:160:49)
    at vh.notifyListeners (EventBoundary.ts:1454:26)
    at vh.notifyTarget (EventBoundary.ts:658:14)
    at vh.propagate (EventBoundary.ts:310:18)
    at vh.dispatchEvent (EventBoundary.ts:210:14)
    at vh.mapPointerMove (EventBoundary.ts:827:74)
    at vh.mapEvent (EventBoundary.ts:231:28)
    at ra.onPointerMove (EventSystem.ts:396:31)
```

**Root cause**
[getSnappedPoint](https://foundryvtt.com/api/classes/foundry.grid.BaseGrid.html#getSnappedPoint) expects the second argument to be an object