### PR TITLE
[FEATURE] Style Background Section and Fix Hover Style for Active Effects Section

### DIFF
--- a/module/TheWitcherTRPG.js
+++ b/module/TheWitcherTRPG.js
@@ -319,3 +319,20 @@ Handlebars.registerHelper({
         return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
     }
 });
+
+Handlebars.registerHelper('eachLimit', function (context, limit, options) {
+    if (!context || typeof context !== 'object') return '';
+  
+    const keys = Object.keys(context);
+    const result = [];
+    
+    for (let i = 0; i < limit; i++) {
+      const key = keys[i];
+      const lifeEvent = context[key];
+      const data = Handlebars.createFrame(options.data || {});
+      data.key = key;
+      
+      result.push(options.fn({ lifeEvent, key }, { data }));
+    }
+    return result.join('');
+  });

--- a/module/actor/sheets/WitcherActorSheet.js
+++ b/module/actor/sheets/WitcherActorSheet.js
@@ -56,6 +56,12 @@ export default class WitcherActorSheet extends ActorSheet {
         context.system = actorData.system;
         context.items = context.actor.items.filter(i => !i.system.isStored);
 
+        context.system.general.lifeEvents = Object.entries(context.system.general.lifeEvents).map(([key, value]) => ({
+            key,
+            ...value,
+        }));
+        context.system.lifeEventCounter = context.system.lifeEventCounter || context.system.general.lifeEvents.length;
+
         this._prepareGeneralInformation(context);
         this._prepareCustomSkills(context);
         this._prepareWeapons(context);
@@ -345,7 +351,7 @@ export default class WitcherActorSheet extends ActorSheet {
 
     _onLifeEventDisplay(event) {
         event.preventDefault();
-        let section = event.currentTarget.closest('.lifeEvents');
+        let section = event.currentTarget.closest('.life-events-card');
         this.actor.update({
             [`system.general.lifeEvents.${section.dataset.event}.isOpened`]:
                 !this.actor.system.general.lifeEvents[section.dataset.event].isOpened

--- a/module/actor/sheets/mixins/activeEffectMixin.js
+++ b/module/actor/sheets/mixins/activeEffectMixin.js
@@ -73,7 +73,9 @@ export let activeEffectMixin = {
         event.stopPropagation();
         let section = event.currentTarget.closest('.effect-row');
         let editor = $(section).find('.effect-description');
-        editor.toggleClass('invisible');
+        if (editor.html().trim() !== "") {
+            editor.toggleClass('invisible');
+        }
     },
 
     activeEffectListener(html) {

--- a/module/data/actor/characterData.js
+++ b/module/data/actor/characterData.js
@@ -13,6 +13,7 @@ export default class CharacterData extends CommonActorData {
 
             general: new fields.SchemaField(general()),
             gender: new fields.StringField({ initial: '' }),
+            lifeEventCounter: new fields.NumberField({ initial: 20 }),
 
             improvementPoints: new fields.NumberField({ initial: 0 }),
             skillTraining1: new fields.SchemaField(skillTraining()),

--- a/styles/activeEffect.css
+++ b/styles/activeEffect.css
@@ -49,6 +49,11 @@
     flex-direction: column;
 }
 
+.effect-row:hover {
+    border-radius: 5px;
+    background-color: rgba(25, 25, 25, 0.05);
+}
+
 .effect-row:last-child {
     border-bottom: none;
 }
@@ -69,6 +74,13 @@
 
 .effect-name > h4 {
     margin-bottom: 0;
+}
+
+.effect-name,
+.effect-source,
+.effect-duration,
+a.effect-control {
+    text-shadow: none;
 }
 
 .effect-source,

--- a/styles/crit-wounds-table.css
+++ b/styles/crit-wounds-table.css
@@ -72,6 +72,13 @@
 .critwound select,
 .critwound textarea {
     border: none;
+    transition: box-shadow 0.1s ease;
+}
+
+.critwound input:hover,
+.critwound select:hover,
+.critwound textarea:hover {
+    box-shadow: 0 0 5px var(--color-shadow-primary);
 }
 
 .critwounds-description {

--- a/styles/tab-background.css
+++ b/styles/tab-background.css
@@ -1,7 +1,8 @@
 .editor {
-    border-style: solid;
-    border-color: rgba(0, 0, 0, 0.308);
-    min-height: 100px;
+    border-radius: 5px;
+    background: rgba(0, 0, 0, 0.05);
+    height: 250px;
+    padding: 5px;
 }
 
 .tox.tox-tinymce {
@@ -9,8 +10,58 @@
     min-width: 200px;
 }
 
-.lifeEvents {
-    margin: 10px;
+.life-events, .notes {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 10px;
+}
+
+.life-events-header, .notes-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px;
+    border-radius: 5px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border: 2px groove #eeede0;
+    margin-top: 20px;
+    margin-bottom: 5px;
+}
+
+.life-events-card {
+    border-radius: 5px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border: 2px groove #eeede0;
+}
+
+.life-events-header > h2, .notes-header > h2 {
+    margin: 0;
+    border-bottom: none;
+    opacity: 0.8;
+}
+
+.life-events-card-header {
+    display: grid;
+    grid-template-columns: 10% 80% 10%;
+    padding: 8px 10px;
+    align-items: center;
+}
+
+.life-events-card-header > h4 {
+    margin: 0;
+}
+
+.padding {
+    padding: 5px 10px;
+}
+
+.life-events-controls {
+    justify-self: center;
+}
+
+.life-events-decades {
+    display: flex;
+    text-align: end;
 }
 
 .add-item {
@@ -18,9 +69,29 @@
 }
 
 .bg-note {
-    width: 80%;
-    float: left;
-    margin: 5px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    border-radius: 5px;
+    padding: 5px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border: 2px groove #eeede0;
+}
+
+.note-header {
+    display: flex;
+    flex-direction: row;
+}
+
+.note-header > a {
+    display: none;
+}
+
+.note-header:hover > a {
+    display: inline-block;
+    text-align: center;
+    text-shadow: none;
+    color: #d02323;
 }
 
 .item-delete {
@@ -30,4 +101,59 @@
 
 .modifier-display {
     min-width: 100px;
+}
+
+.background-info {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.general-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 10px;
+}
+
+.general-homeland, .general-info {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding: 5px;
+    border-radius: 5px;
+    background-color: rgba(0, 0, 0, 0.05);
+    border: 2px groove #eeede0;
+}
+
+.homeland-select {
+    display: flex;
+    gap: 5px;
+}
+
+textarea.life-events-details,
+textarea.inline-edit {
+    resize: vertical;
+    height: auto;
+}
+
+input.details,
+select.details,
+input.life-events-details,
+textarea.life-events-details,
+input.life-events-decades,
+textarea.inline-edit,
+input.inline-edit {
+    border: none;
+    transition: box-shadow 0.1s ease;
+    flex-grow: 1;
+}
+
+input.details:hover,
+select.details:hover,
+input.life-events-details:hover,
+textarea.life-events-details:hover,
+input.life-events-decades:hover,
+textarea.inline-edit:hover,
+input.inline-edit:hover {
+    box-shadow: 0 0 5px var(--color-shadow-primary);
 }

--- a/templates/partials/character/tab-background.hbs
+++ b/templates/partials/character/tab-background.hbs
@@ -1,77 +1,84 @@
 <div class="tab body background">
-    <div class="flexrow BackgroundDescription">
-        <div class="flexcol background scrollable">
-            {{localize "WITCHER.Homeland"}}
-            <select name="system.general.homeland.value" id="homeland-select">
-                {{selectOptions config.homelands selected=system.general.homeland.value localize=true}}
-            </select>
-            {{#if (eq system.general.homeland.value "other")}}
-                <input class="details hometailOther" name="system.general.homeland.otherValue" type="text"
-                    value="{{system.general.homeland.otherValue}}" />
-            {{/if}}
+    <div class="background-info">
+        <div class="background scrollable general-section">
+            <div class="general-homeland">
+                {{localize "WITCHER.Homeland"}}
+                <div class="homeland-select">
+                    <select name="system.general.homeland.value" class="details" id="homeland-select">
+                        {{selectOptions config.homelands selected=system.general.homeland.value localize=true}}
+                    </select>
+                    {{#if (eq system.general.homeland.value "other")}}
+                        <input class="details hometailOther" name="system.general.homeland.otherValue" type="text" value="{{system.general.homeland.otherValue}}" />
+                    {{/if}}
+                </div>
+            </div>
             {{#each system.general.details as |details dt|}}
-                {{localize details.label}}
-                <input class="details {{dt}}" name="system.general.details.{{dt}}.value" type="text"
-                    value="{{details.value}}" />
+                <div class="general-info">
+                    {{localize details.label}}
+                    <input class="details {{dt}}" name="system.general.details.{{dt}}.value" type="text"
+                        value="{{details.value}}" />
+                </div>
             {{/each}}
         </div>
-        {{editor system.general.background.value target="system.general.background.value" button=true
-                 editable=editable}}
+        <div class="background-description">
+            {{editor system.general.background.value target="system.general.background.value" button=true editable=editable}}
+        </div>
     </div>
 
     <div class="flexcol background">
-        <div class="lifeEvents scrollable" id="lifeEvents">
-            <table class="lifevents">
-                <tr class="headerrow lifeEvents">
-                    <th class="header lifeEvents" colspan="3">
-                        {{localize "WITCHER.LifeEvents"}}
-                    </th>
-                </tr>
-                <tr class="titlerow lifeEvents">
-                    <th>{{localize "WITCHER.Decade"}}</th>
-                    <th>{{localize "WITCHER.Event"}}</th>
-                    <th></th>
-                </tr>
-                {{#each system.general.lifeEvents as |events ev|}}
-                    <tr class="tablerow lifeEvents {{ev}}" data-event="{{ev}}">
-                        <td class="{{ev}} events">{{ev}}</td>
-                        <td>
-                            <input class="input lifeEvents" name="system.general.lifeEvents.{{ev}}.value" type="text"
-                                value="{{events.value}}" />
-                        </td>
-                        <td>
-                            {{#unless events.isOpened}}
-                                <a class="life-event-display"><i class="fas fa-chevron-right"></i></a>
-                            {{/unless}}
-                            {{#if events.isOpened}}
-                                <a class="life-event-display"><i class="fas fa-chevron-down"></i></a>
+        <div class="scrollable" id="lifeEvents">
+            <div class="life-events-section">
+                <div class="life-events-header">
+                    <h2>{{localize "WITCHER.LifeEvents"}}</h2>
+                    <h2 class="life-events-decades"><input id="item-count" class="life-events-decades" name="system.lifeEventCounter" min="1" max="20" value="{{system.lifeEventCounter}}" type="number">/20</h2>
+                </div>
+                <div class="life-events">
+                    {{#eachLimit system.general.lifeEvents system.lifeEventCounter}}
+                        <div class="tablerow life-events-card {{this.lifeEvent.key}}" data-event="{{this.lifeEvent.key}}">
+                            <div class="life-events-card-header">
+                                <h4>{{this.lifeEvent.key}}</h4>
+                                {{#unless this.lifeEvent.isOpened}}
+                                    <h4>{{this.lifeEvent.value}}</h4>
+                                {{/unless}}
+                                {{#if this.lifeEvent.isOpened}}
+                                    <input class="input life-events-details" id="life-events-input" name="system.general.lifeEvents.{{this.lifeEvent.key}}.value" type="text" value="{{this.lifeEvent.value}}" />
+                                {{/if}}
+                                <div class="life-events-controls">
+                                    {{#unless this.lifeEvent.isOpened}}
+                                        <a class="life-event-display"><i class="fas fa-chevron-down"></i></a>
+                                    {{/unless}}
+                                    {{#if this.lifeEvent.isOpened}}
+                                        <a class="life-event-display"><i class="fas fa-chevron-up"></i></a>
+                                    {{/if}}
+                                </div>
+                            </div>
+                            {{#if this.lifeEvent.isOpened}}
+                                <div>
+                                    <textarea class="life-events-details" name="system.general.lifeEvents.{{this.lifeEvent.key}}.details">{{this.lifeEvent.details}}</textarea>
+                                </div>
                             {{/if}}
-                        </td>
-                    </tr>
-                    {{#if events.isOpened}}
-                        <tr>
-                            <td colspan="3">
-                                <textarea name="system.general.lifeEvents.{{ev}}.details">{{events.details}}</textarea>
-                            </td>
-                        </tr>
-                    {{/if}}
-                {{/each}}
-            </table>
+                        </div>
+                    {{/eachLimit}}
+                </div>
+            </div>
         </div>
     </div>
-    <div>
-        <h2>{{localize "WITCHER.Notes"}} <a class="add-item" data-itemType="note"><i class="fas fa-plus"></i></a></h2>
-
-        {{#each oldNotes as |note id|}}
+    <div class="notes-section">
+        <div class="notes-header">
+            <h2>{{localize "WITCHER.Notes"}}</h2>
+            <a class="add-item" data-itemType="note"><i class="fas fa-plus"></i></a>
+        </div>
+        <div class="notes">
+            {{#each oldNotes as |note id|}}
             <div class="item bg-note" data-item-id="{{note._id}}">
-                <div class="flex">
+                <div class="note-header">
                     <input class="inline-edit" data-field="name" type="text" value="{{note.name}}" placeholder="name" />
-                    <a class="item-delete"><i class="fas fa-trash-alt"></i></a>
+                    <a class="item-delete"><i class="fas fa-trash"></i></a>
                 </div>
                 <textarea class="inline-edit" rows="5" data-field="system.description">{{system.description}}</textarea>
             </div>
-        {{/each}}
-        {{#each notes as |note|}}
+            {{/each}}
+            {{#each notes as |note|}}
             <div class="item bg-note">
                 <div class="flex">
                     <input type="text" name="system.notes.{{@index}}.title" value="{{note.title}}" />
@@ -79,6 +86,7 @@
                 </div>
                 {{editor note.details target=(concat "system.notes." @index ".details") button=true }}
             </div>
-        {{/each}}
+            {{/each}}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Enhance Styles for Backgroud and Active Effect Section
### Background
- Updated the layout of the General Info and Character Background sections to display in a column direction;
- Styled and limited the height of the "Character Background" section with scroll enabled for longer texts;
- Styled the General Info, Life Event and Notes sections to display as cards
- Style Life Event Style to be displayed as cards
- Added behavior to show a delete icon when hovering over a Notes card;
- In Life Event header, player can set how many decades will be displayed in sheet;
- Adjusted the "Life Event" header to allow players to set the number of decades displayed on the sheet.
- Enhance focus and hover for inputs, select and textarea

| Background 1/2 | Background 2/2|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/43452cf1-d56a-4609-872f-049c17d2c422)| ![image](https://github.com/user-attachments/assets/0fd0c39f-2714-483a-bca1-f277a5a74b77)| 

### Active Effect
- Improved hover behavior for effects in the effect list;
- Fixed unexpected bottom padding when opening an empty effect description;
- Remove text shadow of effect texts;
- Enhanced focus and hover styles for inputs, selects, and textareas in the Critical Wounds section.