### PR TITLE
[BUG] Buttons section not visible in a large dialog window

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1245,20 +1245,12 @@
             "title": "Crafting diagram"
         },
         "Repair": {
+            "action": "Repairing",
             "buttons": {
                 "repair": "Repair",
                 "simulate": "Simulate repair",
                 "request": "Request repair",
                 "gmRepair": "GM repair"
-            },
-            "dialog": {
-                "title": "Repairing",
-                "component": "Component",
-                "quantity": "Quantity",
-                "required": "Required",
-                "cost": "Cost",
-                "totalPrice": "Total price",
-                "unknown": "N/A"
             },
             "result": {
                 "success": "Repair successfull!",
@@ -1285,6 +1277,13 @@
                 "noDiagram": "No associated diagram found for this item",
                 "invalidDiagram": "The type of this diagram is not valid for this item"
             }
+        },
+        "ComponentsList": {
+            "component": "Component",
+            "quantity": "Quantity",
+            "required": "Required",
+            "cost": "Cost",
+            "totalPrice": "Total price"
         }
     }
 }

--- a/module/TheWitcherTRPG.js
+++ b/module/TheWitcherTRPG.js
@@ -76,7 +76,9 @@ async function preloadHandlebarsTemplates() {
 
 
         'systems/TheWitcherTRPG/templates/chat/damage/damageToLocation.hbs',
-        'systems/TheWitcherTRPG/templates/chat/item/repair.hbs'
+        'systems/TheWitcherTRPG/templates/chat/item/repair.hbs',
+
+        'systems/TheWitcherTRPG/templates/partials/components-list.hbs'
     ];
     return loadTemplates(templatePath);
 }

--- a/module/item/mixins/costEditMixin.js
+++ b/module/item/mixins/costEditMixin.js
@@ -1,0 +1,20 @@
+export let costEditMixin = {
+    attachHtmlListeners(callback, ...args) {
+        const elements = Array.from(document.getElementsByClassName('component-cost'))
+        elements.forEach(el => el.addEventListener('change', (_) => callback(this._calculateAdditionalCost(), ...args)))
+    },
+
+    _calculateAdditionalCost() {
+        const totalPriceContainer = document.getElementById('total-price')
+        const additionalCost = Array.from(document.getElementsByClassName('component-cost')).reduce((sum, el) => {
+            const value = parseInt(el.value) ?? 0
+            return sum + value
+        }, 0)
+        const initialPrice = parseInt(totalPriceContainer.getAttribute('data-price'))
+        const newPrice = initialPrice + additionalCost
+
+        totalPriceContainer.innerText = newPrice
+        
+        return additionalCost
+    }
+}

--- a/styles/components-list.css
+++ b/styles/components-list.css
@@ -1,0 +1,20 @@
+table.components-list {
+    margin: 1rem 0;
+}
+
+table.components-list td:nth-child(n+3),
+th:nth-child(n+2) {
+    text-align: center;
+}
+
+tr.components-price td {
+    font-weight: bold;
+    font-size: 1.15em;
+    border-top: 1px solid black;
+    text-align: right;
+    padding: 0.5em 0;
+}
+
+tr.components-price td.total-price {
+    text-align: center;
+}

--- a/styles/repair.css
+++ b/styles/repair.css
@@ -1,12 +1,3 @@
-.repair {
-    margin-top: 10px;
-}
-
-table.repair td:nth-child(n+3),
-th:nth-child(n+2) {
-    text-align: center;
-}
-
 table.repair-info td:first-child {
     text-align: left;
 }
@@ -20,14 +11,13 @@ table.repair-info td {
     font-size: 1.15em;
 }
 
-tr.repair-price td {
-    font-weight: bold;
-    font-size: 1.15em;
-    border-top: 1px solid black;
-    text-align: right;
-    padding: 0.5em 0;
+
+.repair .components-list-container {
+    overflow-y: scroll;
+    max-height: calc(60vh - 50px);
 }
 
-tr.repair-price td.total-price {
-    text-align: center;
+.repair general {
+    overflow-y: scroll;
+    max-height: calc(25vh); 
 }

--- a/styles/witcher-styles.css
+++ b/styles/witcher-styles.css
@@ -19,7 +19,8 @@
 @import "./item-header.css";
 @import "./activeEffect.css";
 @import "./special-skill-table.css";
-@import './repair.css';
+@import "./repair.css";
+@import './components-list.css';
 
 @font-face {
     font-family: 'Thewitcher';

--- a/templates/chat/item/repair.hbs
+++ b/templates/chat/item/repair.hbs
@@ -3,7 +3,7 @@
     {{#if isRequest}}
     <span>{{data.actor.name}} {{ localize "WITCHER.Repair.chat.requestTitle" }} {{data.item.name}}</span>
     {{else}}
-    <span>{{ localize "WITCHER.Repair.dialog.title" }} {{data.item.name}}</span>
+    <span>{{ localize "WITCHER.Repair.action" }} {{data.item.name}}</span>
     {{/if}}
 </h1>
 
@@ -49,12 +49,12 @@
             <td>
                 <img src="icons/svg/item-bag.svg" class="chat-icon" />
             </td>
-            <td colspan="2">{{ name }} <b>(1)</b></td>
+            <td>{{ name }} <b>(1)</b></td>
         </tr>
         {{/each}}
         {{#if isOrder}}
-        <tr class="tablerow repair-price">
-            <td colspan="2">{{ localize "WITCHER.Repair.dialog.totalPrice" }}: {{ data.repairPrice }}</td>
+        <tr class="tablerow components-price">
+            <td colspan="2">{{ localize "WITCHER.ComponentsList.totalPrice" }}: {{ data.repairPrice }}</td>
         </tr>
         {{/if}}
     </tbody>

--- a/templates/dialog/repair-dialog.hbs
+++ b/templates/dialog/repair-dialog.hbs
@@ -1,94 +1,33 @@
-<div class="flexcol">
-    <div class="scrollable">
-        <header class="item-header">
-            <h1 class="itemname">{{localize "WITCHER.Repair.dialog.title" }} {{data.item.name}}</h1>
-            <general>
-                <itemimage>
-                    <img class="profile-img" src="{{data.item.img}}" title="{{data.item.name}}" />
-                </itemimage>
+<div class="repair">
+    <header class="item-header">
+        <h1 class="itemname">{{localize "WITCHER.Repair.action" }} {{data.item.name}}</h1>
+        <general>
+            <itemimage>
+                <img class="profile-img" src="{{data.item.img}}" title="{{data.item.name}}" />
+            </itemimage>
 
-                <table class="information repair-info">
-                    <tr class="item-header-tablerow">
-                        <td>
-                            <label>{{ localize "WITCHER.Repair.params.repairDC" }}</label>
-                        </td>
-                        <td>
-                            {{data.repairDC}}
-                        </td>
-                    </tr>
-                    {{#each data.damagedLocations}}
-                    <tr class="item-header-tablerow">
-                        <td>
-                            <label>{{label}}</label>
-                        </td>
-                        <td>
-                            {{reliabilityValue}}/{{maxReliabilityValue}}
-                        </td>
-                    </tr>
-                    {{/each}}
-                </table>
-            </general>
-        </header>
-        <table class="repair">
-            <thead>
-                <tr class="headerrow">
-                    <th colspan="2" class="header">{{ localize "WITCHER.Repair.dialog.component" }}</th>
-                    <th class="header">{{ localize "WITCHER.Repair.dialog.quantity" }}</th>
-                    <th class="header">{{ localize "WITCHER.Repair.dialog.required" }}</th>
-                    {{#if isRequest}}<th class="header">{{ localize "WITCHER.Repair.dialog.cost" }}</th>{{/if}}
-                </tr>
-            </thead>
-            <tbody>
-                {{#each unknownComponents }}
-                <tr class="tablerow item">
+            <table class="information repair-info">
+                <tr class="item-header-tablerow">
                     <td>
-                        <img src="icons/svg/item-bag.svg" class="item-img" />
+                        <label>{{ localize "WITCHER.Repair.params.repairDC" }}</label>
                     </td>
-                    <td>{{ component.name }}</td>
-                    <td>{{ quantity }} {{#if missingQuantity}}<span class="error-display">({{ missingQuantity
-                            }})</span>{{/if}}</td>
-                    <td>1</td>
-                    {{#if ../isRequest}}<td data-component-id="{{ component._id }}">
-                        {{#if ../canEditCost}}
-                        <input type="text" class="component-cost" data-dtype="Number" />
-                        {{else}}
-                        {{ localize "WITCHER.Repair.dialog.unknown" }}
-                        {{/if}}
-                        </td>
-                    {{/if}}
+                    <td>
+                        {{data.repairDC}}
+                    </td>
+                </tr>
+                {{#each data.damagedLocations}}
+                <tr class="item-header-tablerow">
+                    <td>
+                        <label>{{label}}</label>
+                    </td>
+                    <td>
+                        {{reliabilityValue}}/{{maxReliabilityValue}}
+                    </td>
                 </tr>
                 {{/each}}
-                {{#each missingComponents}}
-                <tr class="tablerow item">
-                    <td>
-                        <img src="{{ component.img }}" class="item-img" />
-                    </td>
-                    <td>{{ component.name }}</td>
-                    <td>{{ quantity }} {{#if missingQuantity}}<span class="error-display">({{ missingQuantity
-                            }})</span>{{/if}}</td>
-                    <td>1</td>
-                    {{#if ../isRequest}}<td>{{ component.cost }}</td>{{/if}}
-                </tr>
-                {{/each}}
-                {{#each ownedComponents}}
-                <tr class="tablerow item">
-                    <td>
-                        <img src="{{ component.img }}" class="item-img" />
-                    </td>
-                    <td>{{ component.name }}</td>
-                    <td>{{ quantity }} {{#if missingQuantity}}<span class="error-display">({{ missingQuantity
-                            }})</span>{{/if}}</td>
-                    <td>1</td>
-                    {{#if ../isRequest}}<td>{{ component.system.cost }}</td>{{/if}}
-                </tr>
-                {{/each}}
-                {{#if isRequest}}
-                <tr class="repair-price">
-                    <td colspan="4">{{ localize "WITCHER.Repair.dialog.totalPrice" }}</td>
-                    <td class="total-price"><span data-price="{{ data.repairPrice }}" id="total-price">{{ data.repairPrice }}</span></td>
-                </tr>
-                {{/if}}
-            </tbody>
-        </table>
-    </div>
+            </table>
+        </general>
+    </header>
+    {{>"systems/TheWitcherTRPG/templates/partials/components-list.hbs" components=components showCost=isRequest
+    canEditCost=canEditCost totalPrice=data.repairPrice}}
 </div>

--- a/templates/partials/components-list.hbs
+++ b/templates/partials/components-list.hbs
@@ -1,0 +1,41 @@
+<div class="components-list-container">
+    <table class="components-list">
+        <thead>
+            <tr class="headerrow">
+                <th colspan="2" class="header">{{ localize "WITCHER.ComponentsList.component" }}</th>
+                <th class="header">{{ localize "WITCHER.ComponentsList.quantity" }}</th>
+                <th class="header">{{ localize "WITCHER.ComponentsList.required" }}</th>
+                {{#if showCost }}<th class="header">{{ localize "WITCHER.ComponentsList.cost" }}</th>{{/if}}
+            </tr>
+        </thead>
+        <tbody>
+            {{#each components}}
+            <tr class="tablerow item">
+                <td>
+                    <img src="{{ img }}" class="item-img" />
+                </td>
+                <td>{{ name }}</td>
+                <td>{{ quantity }} {{#if missingQuantity}}<span class="error-display">({{ missingQuantity
+                        }})</span>{{/if}}</td>
+                <td>{{ required }}</td>
+                {{#if ../showCost}}
+                <td>
+                    {{#if (and ../canEditCost (eq cost 0)) }}
+                    <input type="number" class="component-cost" data-dtype="Number" />
+                    {{else}}
+                    {{ cost }}
+                    {{/if}}
+                </td>
+                {{/if}}
+            </tr>
+            {{/each}}
+            {{#if showCost}}
+            <tr class="components-price">
+                <td colspan="4">{{ localize "WITCHER.ComponentsList.totalPrice" }}</td>
+                <td class="total-price"><span data-price="{{ totalPrice }}" id="total-price">{{ totalPrice }}</span>
+                </td>
+            </tr>
+            {{/if}}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
**Describe the bug**
Can't see the footer (buttons) in a dialog when the content section is too large. The content section is scrollable, but the container element isn't

**To Reproduce**
Steps to reproduce the behavior:
1. Open a repair dialog for an item with a large amount of components
2. You'll see the header and components section, but the footer buttons are not visible

**Expected behavior**
The dialog can be scrolled to reveal the buttons

**Screenshots**
Before the fix:
![image](https://github.com/user-attachments/assets/9961e2fb-a508-4ecb-95f0-44cbc3400dc4)

After the fix:
![image](https://github.com/user-attachments/assets/951f840d-ca69-49a7-94a7-de9e4fa179ad)

**Versions (please complete the following information):**
 - Foundry: v12.331
 - System: v12.15.2

**Additional context**
I'm not sure if introducing a system-wide (non-repair-specific) CSS class is the best approach, but it could be helpful for other dialog use cases as well
