### PR TITLE
[BUGFIX] Fix Responsiveness for Profession Section in Monster Sheet

### DIFF
--- a/styles/profession-sheet.css
+++ b/styles/profession-sheet.css
@@ -147,6 +147,12 @@ input.profession-skill-input {
     justify-content: flex-start;
 }
 
+.monster-profession-flex {
+    display: flex; 
+    flex-direction: column; 
+    justify-content: flex-start;
+}
+
 .profession-card .editor {
     height: 150px;
     border-radius: 0 0 5px 5px;

--- a/templates/partials/monster/monster-profession-skill-display.hbs
+++ b/templates/partials/monster/monster-profession-skill-display.hbs
@@ -7,7 +7,7 @@
             <a class='item-delete'><i class='fas fa-trash-alt'></i></a>
         </h1>
         <div class='profession-layout'>
-            <div class='profession-flex'>
+            <div class='monster-profession-flex'>
                 <div class='profession-card defining-skill'>
                     <div
                         class='flex defining-skill-header profession-display'

--- a/templates/sheets/actor/monster-sheet.hbs
+++ b/templates/sheets/actor/monster-sheet.hbs
@@ -314,6 +314,9 @@
 
             <nav class="sheet-tabs tabs" data-group="primary">
                 <a data-tab="skills"> {{localize "WITCHER.Monster.SkillTab"}}</a>
+                {{#if (eq system.category "Humanoid")}}
+                <a data-tab="profession"> {{localize "WITCHER.Profession"}}</a>
+                {{/if}}
                 <a data-tab="inventory">{{localize "WITCHER.Monster.InventoryTab"}} </a>
                 <a data-tab="details"> {{localize "WITCHER.Monster.DetailsTab"}}</a>
                 <a data-tab="spells"> {{localize "WITCHER.Monster.SpellsTab"}}</a>
@@ -325,12 +328,16 @@
                 <div class="tab" data-group="primary" data-tab="skills">
                     {{> "systems/TheWitcherTRPG/templates/partials/monster/monster-skill-tab.hbs"}}
                 </div>
+                {{#if (eq system.category "Humanoid")}}
+                <div class="tab" data-group="primary" data-tab="profession">
+                    {{> "systems/TheWitcherTRPG/templates/partials/monster/monster-profession-skill-display.hbs"}}
+                </div>
+                {{/if}}
                 <div class="tab" data-group="primary" data-tab="inventory">
                     {{>"systems/TheWitcherTRPG/templates/partials/monster/monster-inventory-tab.hbs"}}
                 </div>
                 <div class="tab" data-group="primary" data-tab="details">
                     {{>"systems/TheWitcherTRPG/templates/partials/monster/monster-details-tab.hbs"}}
-                    {{> "systems/TheWitcherTRPG/templates/partials/monster/monster-profession-skill-display.hbs"}}
                 </div>
                 <div class="tab" data-group="primary" data-tab="spells">
                     {{> "systems/TheWitcherTRPG/templates/partials/monster/monster-spell-tab.hbs"}}


### PR DESCRIPTION
## This PR closes the issue https://github.com/witchertrpg-foundryvtt/TheWitcherTRPG/issues/185
### Bugfix
- Fix flex-direction to `column` instead of `row`
- Profession Section will appear only if the monster  type is `Humanoid`
![image](https://github.com/user-attachments/assets/baeb606f-9fef-454f-8818-f68739d5fca7)
