### PR TITLE
[BUG] The system isn't loading on Forge VTT

### DIFF
--- a/module/setup/registerDataModels.js
+++ b/module/setup/registerDataModels.js
@@ -25,7 +25,7 @@ import SkillItemData from '../data/item/skillItemData.js';
 import HexData from '../data/item/hexData.js';
 import RitualData from '../data/item/ritualData.js';
 import AttackMessageData from '../data/chatMessage/attackMessageData.js';
-import WitcherChatMessage from '../chatMessage/WitcherChatMessage.js';
+import WitcherChatMessage from '../chatMessage/witcherChatMessage.js';
 
 export const registerDataModels = () => {
     foundry.utils.mergeObject(CONFIG.Actor.dataModels, {


### PR DESCRIPTION
**Describe the bug**
The system isn't loading on externally-hosted installations - [Forge VTT](https://eu.forge-vtt.com/) in my case

**To Reproduce**
Steps to reproduce the behavior:
1. Launch the game
2. Try to open any actor/item sheet or the system's settings

**Expected behavior**
Actor/item sheet renders as usual

**Screenshots**
![image](https://github.com/user-attachments/assets/8f1ab56a-8c78-41e0-9902-187b4c3b4bb1)
![image](https://github.com/user-attachments/assets/50998836-604b-449e-97d9-0636bd5fc610)
![image](https://github.com/user-attachments/assets/d3fdc8f0-4a12-41dd-bab0-25cd5d5925d9)


**Versions (please complete the following information):**
 - Foundry version: v12.331
 - System version: v12.17.1
 
 **Root cause**
 Supposedly failed import :
```js
Failed to load resource: the server responded with a status of 404 () 
 systems/TheWitcherTRPG/module/chatMessage/WitcherChatMessage.js:1
 ```

![image](https://github.com/user-attachments/assets/f582b6b5-321d-44e5-993a-8911da21c013)


**Additional context**
Might affect installations on any case-sensitive OS or might be some Forge-specific configuration