### PR TITLE
[BUG] Damage is not applied from status effects, crit damage, bonus crit damage. Unexpected oil damage applications

### DIFF
--- a/module/actor/mixins/damageMixin.js
+++ b/module/actor/mixins/damageMixin.js
@@ -7,8 +7,7 @@ export let damageMixin = {
             this,
             null,
             crit.critdamage,
-            { damageProperties: { bypassesNaturalArmor: true, bypassesWornArmor: true } },
-            this.getLocationObject('torso'),
+            { damageProperties: { bypassesNaturalArmor: true, bypassesWornArmor: true }, location: this.getLocationObject('torso') },
             'hp'
         );
     },
@@ -18,8 +17,7 @@ export let damageMixin = {
             this,
             null,
             crit.bonusdamage,
-            { damageProperties: { bypassesNaturalArmor: true, bypassesWornArmor: true } },
-            this.getLocationObject('torso'),
+            { damageProperties: { bypassesNaturalArmor: true, bypassesWornArmor: true }, location: this.getLocationObject('torso') },
             'hp'
         );
     },

--- a/module/scripts/combat/applyDamage.js
+++ b/module/scripts/combat/applyDamage.js
@@ -109,8 +109,8 @@ async function createApplyDamageDialog(actor, damageObject) {
     };
 }
 
-async function applyDamageFromStatus(actor, totalDamage, damageObject, location, derivedStat) {
-    await applyDamage(actor, null, totalDamage, damageObject, location, derivedStat, totalDamage);
+async function applyDamageFromStatus(actor, totalDamage, damageObject, derivedStat) {
+    await applyDamage(actor, null, totalDamage, damageObject, derivedStat, totalDamage);
 }
 
 async function applyDamageFromMessage(actor, totalDamage, messageId, derivedStat) {
@@ -156,7 +156,7 @@ async function applyDamage(actor, dialogData, totalDamage, damageObject, derived
         totalDamage -= shield;
     }
 
-    if (damageObject.damageProperties.oilEffect === actor.system.category) {
+    if (actor.system.category && (damageObject.damageProperties.oilEffect === actor.system.category)) {
         totalDamage += 5;
         infoTotalDmg += `+5[${game.i18n.localize('WITCHER.Damage.oil')}]`;
     }
@@ -208,9 +208,11 @@ async function applyDamageToAllLocations(actor, dialogData, damage, totalDamage,
     let locations = actor.getAllLocations().map(location => actor.getLocationObject(location));
 
     let resultPromises = [];
-    locations.forEach(location =>
-        resultPromises.push(calculateDamageWithLocation(actor, dialogData, damage, totalDamage, infoTotalDmg, location))
-    );
+    locations.forEach(location => {
+        damage.location = location
+
+        resultPromises.push(calculateDamageWithLocation(actor, dialogData, damage, totalDamage, infoTotalDmg))
+    });
 
     let results = await Promise.all(resultPromises);
 

--- a/module/scripts/statusEffects/statusEffectHook.js
+++ b/module/scripts/statusEffects/statusEffectHook.js
@@ -33,15 +33,15 @@ async function applyCombatEffects(actor, status) {
             damageToAllLocations: status.combat.turn?.damage.allLocations,
             effects: [],
             bypassesNaturalArmor: status.combat.turn?.damage.ignoreArmor,
-            bypassesWornArmor: status.combat.turn?.damage.ignoreArmor
-        }
+            bypassesWornArmor: status.combat.turn?.damage.ignoreArmor,
+        },
+        location: actor.getLocationObject('torso')
     };
     if (status.combat.turn?.damage.nonLethal) {
         await applyDamageFromStatus(
             actor,
             status.combat.turn?.damage.damage,
             damage,
-            actor.getLocationObject('torso'),
             'sta'
         );
     } else {
@@ -49,7 +49,6 @@ async function applyCombatEffects(actor, status) {
             actor,
             status.combat.turn?.damage.damage,
             damage,
-            actor.getLocationObject('torso'),
             'hp'
         );
     }


### PR DESCRIPTION
**Describe the bug**
Damage from status effects (Fire, Poison, etc) won't trigger on affected actor.
Critical damage/bonus critical damage can't be applied.
Status effect and critical damage automatically adds oil damage to non-monster actors

**To Reproduce**

Status effects:
1. Start the combat
2. Cast any spell/attack that applies Fire or Poison status effect
3. Effect is applied correctly and can be observed in Active Effect tab
3. Click 'Next round'
4. No damage is applied

Crit damage + oil damage:
1. Roll a crit 
2. Try to apply the damage
3. Damage is not applied

**Expected behavior**
Damage is applied

**Screenshots**
![image](https://github.com/user-attachments/assets/3f6db70c-4f8c-46a0-8c99-2bc98b87abcc)
![image](https://github.com/user-attachments/assets/a82c523a-2459-4a40-9dfc-8620c358ff84)


**Versions (please complete the following information):**
 - Foundry Version v12.331
 - Version: v12.18.1

**Root cause**
Damage application: `applyDamage` functions expects `location` to be a part of `damageObject`.
Oil damage: If there is no `oilEffect` in `damageProperties` and actor doesn't have `system.category` both variables are undefined and condition is met
