### PR TITLE
[FEATURE] - More Improvements on Wepon Section

### DIFF
--- a/module/actor/sheets/investigation/WitcherMysterySheet.js
+++ b/module/actor/sheets/investigation/WitcherMysterySheet.js
@@ -43,6 +43,7 @@ export default class WitcherMysterySheet extends ActorSheet {
   }
 
   async _onItemAdd(event) {
+    event.preventDefault();
     let element = event.currentTarget
     let itemData = {
       name: `new ${element.dataset.itemtype}`,

--- a/styles/system-styles.css
+++ b/styles/system-styles.css
@@ -114,16 +114,6 @@
     background-color: rgba(25, 25, 25, 0.05);
 }
 
-.weapon-info {
-    display: flex;
-    flex-direction: column;
-    padding: 10px 5px;
-    gap: 5px;
-    box-shadow:
-        inset -2px 8px 8px -10px #9a9991,
-        inset -2px -8px 8px -10px #9a9991;
-}
-
 .label-info {
     margin-left: 5px;
 }

--- a/styles/tab-inventory-list.css
+++ b/styles/tab-inventory-list.css
@@ -1,6 +1,5 @@
-.weapon-header {
+.list-header {
     display: grid;
-    grid-template-columns: 33px 2fr 1fr;
     align-items: center;
     padding: 5px;
     border-radius: 5px;
@@ -8,31 +7,60 @@
     border: 2px groove #eeede0;
     margin: 5px 0;
     gap: 20px;
+    list-style: none;
+    cursor: pointer;
 }
 
-.weapon-header h3 {
+.list-header::before {
+    content: '\f078';
+    font-family: 'Font Awesome 5 Free';
+    font-weight: 900;
+    transition: transform 0.3s ease;
+    justify-self: center;
+    cursor: pointer;
+}
+
+details[open] .list-header::before {
+    transform: rotate(180deg);
+}
+
+.list-header h3 {
     margin: 0;
     border: none;
 }
 
-.weapon-label {
+.list-item-info {
+    display: flex;
+    flex-direction: column;
+    padding: 10px 5px;
+    gap: 5px;
+    box-shadow:
+        inset -2px 8px 8px -10px #9a9991,
+        inset -2px -8px 8px -10px #9a9991;
+}
+
+.list-item-info.invisible {
+    display: none;
+}
+
+.list-label {
     display: flex;
     flex-direction: row;
     align-items: center;
 }
 
-.weapon-label > span {
+.list-label > span {
     width: 70px;
     text-align: center;
     padding: 5px;
 }
 
-.weapon-header .weapon-label > span {
+.list-header .list-label > span {
     border-left: 1px solid #9a9991;
     box-sizing: border-box;
 }
 
-.weapon-details .weapon-label > span:hover {
+.list-details .list-label > span:hover {
     padding: 5px;
     background-color: rgba(255, 255, 255, 0.3);
     border-radius: 5px;
@@ -40,12 +68,12 @@
     transition: all 0.3s ease;
 }
 
-.weapon-info h3,
-.item-description h3 {
+.list-item-info h3,
+.list-item-description h3 {
     border-bottom: 1px solid #9a9991;
 }
 
-.weapon-list {
+.list {
     display: flex;
     flex-direction: column;
     list-style-type: none;
@@ -54,13 +82,18 @@
     gap: 10px;
 }
 
-.weapon-list.invisible {
-    display: none;
+.list-item {
+    flex-direction: column;
 }
 
-.weapon-details {
+.list-controls {
+    display: flex;
+    justify-content: center;
+    gap: 5px;
+}
+
+.list-details {
     display: grid;
-    grid-template-columns: 40px 2fr 1fr;
     margin: 0 7px;
     border-bottom: 1px solid rgba(25, 24, 19, 0.2);
     align-items: center;
@@ -68,13 +101,22 @@
     gap: 20px;
 }
 
-.weapon-details:last-child {
+.list-details:last-child {
     border: none;
 }
 
-.weapon-details:hover {
+.list-details:hover {
     border-radius: 5px;
     background-color: rgba(25, 25, 25, 0.05);
+}
+
+.list-details:hover > .item-weapon-display > img {
+    display: none;
+}
+
+.list-details:hover > .item-weapon-display > span {
+    display: flex;
+    font-size: 1rem;
 }
 
 .item-weapon-display {
@@ -85,15 +127,7 @@
     display: none;
 }
 
-.weapon-details:hover > .item-weapon-display > img {
-    display: none;
-}
-
-.weapon-details:hover > .item-weapon-display > span {
-    display: flex;
-}
-
-.weapon-image {
+.item-list-image {
     flex-wrap: wrap;
     place-content: center;
     text-shadow: none;
@@ -103,22 +137,6 @@
     width: 40px;
     height: 40px;
     border: 1px solid rgba(25, 24, 19, 0.6);
-}
-
-.weapon-item {
-    flex-direction: column;
-}
-
-.weapon-enhancement {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-}
-
-.weapon-controls {
-    display: flex;
-    justify-content: center;
-    gap: 5px;
 }
 
 .reliable-details {
@@ -142,11 +160,3 @@ a.equipped {
     text-shadow: none;
 }
 
-a.weapon-list-display {
-    text-shadow: none;
-    text-align: center;
-}
-
-a.weapon-list-display > i {
-    transition: all 0.3s ease;
-}

--- a/styles/tab-inventory.css
+++ b/styles/tab-inventory.css
@@ -108,3 +108,16 @@ table th {
 .item-img-wrapper .item-show:hover .fa {
     display: inline-block;
 }
+
+.weapon-header {
+    grid-template-columns: 33px 2fr 1fr;
+}
+
+.weapon-details {
+    grid-template-columns: 40px 2fr 1fr;
+}
+.weapon-enhancement {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}

--- a/styles/witcher-styles.css
+++ b/styles/witcher-styles.css
@@ -1,28 +1,28 @@
-@import "./character-header.css";
-@import "./armor-sheet.css";
-@import "./attack-sheet.css";
-@import "./system-styles.css";
-@import "./monster-sheet.css";
-@import "./tab-background.css";
-@import "./tab-inventory.css";
-@import "./tab-skills.css";
-@import "./monster-skill-tab.css";
-@import "./loot-sheet.css";
-@import "./profession-sheet.css";
-@import "./race-sheet.css";
-@import "./crit-wounds-table.css";
-@import "./item-sheets.css";
-@import "./substances.css";
-@import "./weapon-roll.css";
-@import "./container-sheet.css";
-@import "./chat.css";
-@import "./item-header.css";
-@import "./activeEffect.css";
-@import "./special-skill-table.css";
-@import "./repair.css";
+@import './character-header.css';
+@import './armor-sheet.css';
+@import './attack-sheet.css';
+@import './system-styles.css';
+@import './monster-sheet.css';
+@import './tab-background.css';
+@import './tab-inventory.css';
+@import './tab-skills.css';
+@import './monster-skill-tab.css';
+@import './loot-sheet.css';
+@import './profession-sheet.css';
+@import './race-sheet.css';
+@import './crit-wounds-table.css';
+@import './item-sheets.css';
+@import './substances.css';
+@import './weapon-roll.css';
+@import './container-sheet.css';
+@import './chat.css';
+@import './item-header.css';
+@import './activeEffect.css';
+@import './special-skill-table.css';
+@import './repair.css';
 @import './components-list.css';
 @import './dialog.css';
-@import './tab-inventory-weapon.css';
+@import './tab-inventory-list.css';
 
 @font-face {
     font-family: 'Thewitcher';
@@ -33,27 +33,27 @@
     font-family: Thewitcher;
 }
 
-.sheet-body details summary > * {
+.skill-column details summary > * {
     display: inline;
 }
 
-.sheet-body details[open] > summary::after {
+.skill-column details[open] > summary::before {
     transform: rotate(-135deg) translatey(-0.3em);
 }
 
-.sheet-body summary {
+.skill-column summary {
     list-style: none;
     padding-left: 4px;
     cursor: pointer;
 }
 
-.sheet-body summary::after {
+.skill-column summary::before {
     display: inline-block;
     content: '';
     border-right: 2px solid;
     border-bottom: 2px solid;
     position: relative;
-    left: 0.75em;
+    left: 0;
     height: 0.75em;
     width: 0.75em;
     transform: rotate(45deg) translatey(-0.1em);

--- a/templates/partials/character/tab-inventory.hbs
+++ b/templates/partials/character/tab-inventory.hbs
@@ -48,147 +48,146 @@
             </div>
         </div>
 
-        <div class="weapon-header">
-            <a class="weapon-list-display">
-                <i class="fa-solid fa-chevron-up"></i>
-            </a>
-            <h3>{{localize "WITCHER.Inventory.Weapons"}}</h3>
-            <div class="weapon-label">
-                <span>{{localize "WITCHER.table.Damage"}}</span>
-                <span>{{localize "WITCHER.table.Reliability"}}</span>
-                <span>{{localize "WITCHER.table.Quantity"}}</span>
-                <span>
-                    <a class="add-item" data-itemType="weapon">
-                        <i class="fas fa-plus"></i>
-                    </a>
-                </span>
-            </div>
-        </div>
-
-        <ol class="weapon-list item-table item-list">
-            {{#each weapons as |weapon id|}}
-                <li class="item weapon-item" data-item-id="{{weapon.id}}" data-type="weapon">
-                    <div class="weapon-details">
-                        <a class="item-weapon-display">
-                            <img class="item-image weapon-image" src="{{weapon.img}}" alt="">
-                            <span class="item-image weapon-image" title="{{localize 'WITCHER.Item.openDescription'}}">
-                                <i class="fa-solid fa-book"></i>
-                            </span>
+        <details open>
+            <summary class="list-header weapon-header">
+                <h3>{{localize "WITCHER.Inventory.Weapons"}}</h3>
+                <div class="list-label">
+                    <span>{{localize "WITCHER.table.Damage"}}</span>
+                    <span>{{localize "WITCHER.table.Reliability"}}</span>
+                    <span>{{localize "WITCHER.table.Quantity"}}</span>
+                    <span>
+                        <a class="add-item" data-itemType="weapon">
+                            <i class="fas fa-plus"></i>
                         </a>
-                        <div><a class="item-roll">{{weapon.name}}</a></div>
-                        <div class="weapon-label">
-                            <span>{{weapon.system.damage}}</span>
-                            <span class="reliable-details">
-                                <input class="inline-edit reliable-info" data-field="system.reliable" type="text"
-                                    value="{{weapon.system.reliable}}" data-dtype="Number" /> | <span
-                                    class="">{{weapon.system.maxReliability}}</span>
-                            </span>
-                            <span><input class="inline-edit item-quantity" data-field="system.quantity" type="text"
-                                    value="{{weapon.system.quantity}}" data-dtype="Number" /></span>
-                            <span class="weapon-controls">
-                                <a class="item-equip {{#if weapon.system.equipped}}equipped{{/if}}" title="{{#if weapon.system.equipped}}
-                                    {{localize 'WITCHER.Item.Equipped'}}
-                                {{else}}
-                                    {{localize 'WITCHER.Item.NotEquipped'}}
-                                {{/if}}">
-                                    <i
-                                        class="{{#if weapon.system.equipped}}fa-solid{{else}}fa-regular{{/if}} fa-hand"></i>
-                                </a>
-                                {{#if weapon.canBeRepaired}}
-                                    <a class="item-repair" title="{{localize 'WITCHER.Repair.buttons.repair'}}"><i
-                                            class="fas fa-screwdriver-wrench"></i></a>
-                                {{/if}}
-                            </span>
-                        </div>
-                    </div>
-                    <div class="invisible item-info weapon-info">
-                        <div class="item-tags">
-                            <span class="item-tag" title="{{localize "WITCHER.Weapon.Type"}}">
-                                {{weapon.system.type.text}}
-                            </span>
-                            <span class="item-tag" title="{{localize "WITCHER.Weapon.Range"}}">
-                                <i class="fa-solid fa-ruler"></i>
-                                {{weapon.system.range}}
-                            </span>
-                            {{#if (gt weapon.system.accuracy 0)}}
-                                <span class="item-tag" title="{{localize "WITCHER.Weapon.WeaponAccuracy"}}">
-                                    <i class="fa-solid fa-crosshairs"></i>
-                                    +{{weapon.system.accuracy}}
+                    </span>
+                </div>
+            </summary>  
+            <ol class="list item-table item-list">
+                {{#each weapons as |weapon id|}}
+                    <li class="item list-item" data-item-id="{{weapon.id}}" data-type="weapon">
+                        <div class="list-details weapon-details">
+                            <a class="item-weapon-display">
+                                <img class="item-image item-list-image" src="{{weapon.img}}">
+                                <span class="item-image item-list-image" data-tooltip="{{localize 'WITCHER.Item.openDescription'}}">
+                                    <i class="fa-solid fa-book"></i>
                                 </span>
-                            {{/if}}
-                            {{#if weapon.system.isAmmo}}
-                                <span class="item-tag">
-                                    {{localize "WITCHER.Weapon.isAmmunition"}}
+                            </a>
+                            <div><a class="item-roll">{{weapon.name}}</a></div>
+                            <div class="list-label">
+                                <span>{{weapon.system.damage}}</span>
+                                <span class="reliable-details">
+                                    <input class="inline-edit reliable-info" data-field="system.reliable" type="text"
+                                        value="{{weapon.system.reliable}}" data-dtype="Number" /> | <span
+                                        class="">{{weapon.system.maxReliability}}</span>
                                 </span>
-                            {{else}}
-                                <span class="item-tag" title="{{localize "WITCHER.Weapon.Hands.title"}}">
-                                    <i class="fa-solid fa-hand"></i>
-                                    {{ localize (lookup ../config.weapon.hands weapon.system.hands) }}
+                                <span><input class="inline-edit item-quantity" data-field="system.quantity" type="text"
+                                        value="{{weapon.system.quantity}}" data-dtype="Number" /></span>
+                                <span class="list-controls">
+                                    <a class="item-equip {{#if weapon.system.equipped}}equipped{{/if}}" data-tooltip="{{#if weapon.system.equipped}}
+                                        {{localize 'WITCHER.Item.Equipped'}}
+                                    {{else}}
+                                        {{localize 'WITCHER.Item.NotEquipped'}}
+                                    {{/if}}">
+                                        <i class="{{#if weapon.system.equipped}}fa-solid{{else}}fa-regular{{/if}} fa-hand"></i>
+                                    </a>
+                                    {{#if weapon.canBeRepaired}}
+                                        <a class="item-repair" data-tooltip="{{localize 'WITCHER.Repair.buttons.repair'}}"><i
+                                                class="fas fa-screwdriver-wrench"></i></a>
+                                    {{/if}}
                                 </span>
-                            {{/if}}
-
-                            <span class="item-tag" title="{{localize "WITCHER.Weapon.Concealment"}}">
-                                <i class="fa-solid fa-eye-slash"></i>
-                                {{ localize (lookup ../config.Concealment weapon.system.conceal) }}
-                            </span>
-                            <span class="item-tag" title="{{localize "WITCHER.Item.Weight"}}">
-                                <i class="fa-solid fa-weight-hanging"></i>
-                                {{weapon.system.weight}}
-                            </span>
-                        </div>
-                        {{#if weapon.system.description}}
-                            <div class="item-description">
-                                <h3>{{localize "WITCHER.Item.Description"}}</h3>
-                                {{weapon.system.description}}
                             </div>
-                        {{/if}}
-                        {{#unless (eq type "enhancement")}}
-                            {{#if weapon.system.enhancementItems.length}}
-                                <div class="weapon-enhancements">
-                                    <h3>{{localize "WITCHER.Dialog.Enhancement"}}</h3>
-                                    <div class="enhancement-list">
-                                        {{#each weapon.system.enhancementItems as |enhancement id|}}
-                                            {{#if enhancement.img}}
-                                                <div class="item weapon-enhancement" data-item-id="{{enhancement.id}}">
-                                                    <div class="enhancement-label">
-                                                        <img class="enhancement-img no-margin"
-                                                            src="{{enhancement.img}}" />
-                                                        <span class="">{{enhancement.name}}</span>
-                                                    </div>
-                                                    <div class="enhancement-info invisible">
-                                                        <div class="item-tags">
-                                                            {{#each enhancement.system.effects as |effects|}}
-                                                                {{#if (gt effects.percentage 0)}}
-                                                                    <div class="item-tag">
-                                                                        {{effects.statusEffect}}
-                                                                        {{effects.percentage}}%
-                                                                    </div>
-                                                                {{/if}}
-                                                            {{/each}}
-                                                        </div>
-                                                        <div class="enhancement-effects-name">
-                                                            {{#each enhancement.system.effects as |effects|}}
-                                                                {{effects.name}}
-                                                            {{/each}}
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            {{else}}
-                                                <a class="enhancement-label enhancement-weapon-slot">
-                                                    <div class="enhancement-slot">
-                                                    </div>
-                                                    <span>{{localize 'WITCHER.Item.equipEnhancement'}}</span>
-                                                </a>
-                                            {{/if}}
-                                        {{/each}}
-                                    </div>
+                        </div>
+                        <div class="invisible item-info list-item-info">
+                            <div class="item-tags">
+                                <span class="item-tag" data-tooltip="{{localize "WITCHER.Weapon.Type"}}">
+                                    {{weapon.system.type.text}}
+                                </span>
+                                <span class="item-tag" data-tooltip="{{localize "WITCHER.Weapon.Range"}}">
+                                    <i class="fa-solid fa-ruler"></i>
+                                    {{weapon.system.range}}
+                                </span>
+                                {{#if (gt weapon.system.accuracy 0)}}
+                                    <span class="item-tag" data-tooltip="{{localize "WITCHER.Weapon.WeaponAccuracy"}}">
+                                        <i class="fa-solid fa-crosshairs"></i>
+                                        +{{weapon.system.accuracy}}
+                                    </span>
+                                {{/if}}
+                                {{#if weapon.system.isAmmo}}
+                                    <span class="item-tag">
+                                        {{localize "WITCHER.Weapon.isAmmunition"}}
+                                    </span>
+                                {{else}}
+                                    <span class="item-tag" data-tooltip="{{localize "WITCHER.Weapon.Hands.title"}}">
+                                        <i class="fa-solid fa-hand"></i>
+                                        {{ localize (lookup ../config.weapon.hands weapon.system.hands) }}
+                                    </span>
+                                {{/if}}
+
+                                <span class="item-tag" data-tooltip="{{localize "WITCHER.Weapon.Concealment"}}">
+                                    <i class="fa-solid fa-eye-slash"></i>
+                                    {{ localize (lookup ../config.Concealment weapon.system.conceal) }}
+                                </span>
+                                <span class="item-tag" data-tooltip="{{localize "WITCHER.Item.Weight"}}">
+                                    <i class="fa-solid fa-weight-hanging"></i>
+                                    {{weapon.system.weight}}
+                                </span>
+                            </div>
+                            {{#if weapon.system.description}}
+                                <div class="list-item-description">
+                                    <h3>{{localize "WITCHER.Item.Description"}}</h3>
+                                    {{weapon.system.description}}
                                 </div>
                             {{/if}}
-                        {{/unless}}
-                    </div>
-                </li>
-            {{/each}}
-        </ol>
+                            {{#unless (eq type "enhancement")}}
+                                {{#if weapon.system.enhancementItems.length}}
+                                    <div class="weapon-enhancements">
+                                        <h3>{{localize "WITCHER.Dialog.Enhancement"}}</h3>
+                                        <div class="enhancement-list">
+                                            {{#each weapon.system.enhancementItems as |enhancement id|}}
+                                                {{#if enhancement.img}}
+                                                    <div class="item weapon-enhancement" data-item-id="{{enhancement.id}}">
+                                                        <div class="enhancement-label">
+                                                            <img class="enhancement-img no-margin"
+                                                                src="{{enhancement.img}}" />
+                                                            <span class="">{{enhancement.name}}</span>
+                                                        </div>
+                                                        <div class="enhancement-info invisible">
+                                                            <div class="item-tags">
+                                                                {{#each enhancement.system.effects as |effects|}}
+                                                                    {{#if (gt effects.percentage 0)}}
+                                                                        <div class="item-tag">
+                                                                            {{effects.statusEffect}}
+                                                                            {{effects.percentage}}%
+                                                                        </div>
+                                                                    {{/if}}
+                                                                {{/each}}
+                                                            </div>
+                                                            <div class="enhancement-effects-name">
+                                                                {{#each enhancement.system.effects as |effects|}}
+                                                                    {{effects.name}}
+                                                                {{/each}}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                {{else}}
+                                                    <a class="enhancement-label enhancement-weapon-slot">
+                                                        <div class="enhancement-slot">
+                                                        </div>
+                                                        <span>{{localize 'WITCHER.Item.equipEnhancement'}}</span>
+                                                    </a>
+                                                {{/if}}
+                                            {{/each}}
+                                        </div>
+                                    </div>
+                                {{/if}}
+                            {{/unless}}
+                        </div>
+                    </li>
+                {{/each}}
+            </ol>
+        </details>
+
+
     </div>
 
     <div class="armor-section">


### PR DESCRIPTION
## Features
- refactor section to use `details` element.
- rename class `weapon-*` to `list-*` to be used in other sections.
- replace `title` to `data-tooltip` because its a native foundry tooltip.
- change `sheet-body` to `skill-colum` to avoid conflicts with weapon section.

After this changes, i pretend to start improve others sections.