### PR TITLE
Fixed Derived Stat Focus translation

### DIFF
--- a/lang/pl.json
+++ b/lang/pl.json
@@ -121,7 +121,7 @@
             "DerStat.Shield": "Tarcza",
             "DerStat.Sta": "PW",
             "DerStat.Resolve": "Determinacja",
-            "DerStat.Focus": "Fokus",
+            "DerStat.Focus": "Skupienie",
             "DerStat.Punch": "Pięść",
             "DerStat.Kick": "Kop",
             "Initiative": "Inicjatywa",


### PR DESCRIPTION
Quick fix for the polish translation of the Focus derived stat on the main player stats character sheet.