### PR TITLE
Fix fast strikes not attacking second time

### DIFF
--- a/module/actor/mixins/weaponAttackMixin.js
+++ b/module/actor/mixins/weaponAttackMixin.js
@@ -174,6 +174,8 @@ export let weaponAttackMixin = {
             }
         });
 
+        damage.properties = damage.properties.toObject(false);
+
         for (let i = 0; i < attacknumber; i++) {
             let attFormula = '1d10+';
             let skill = CONFIG.WITCHER.skillMap[attack.skill];
@@ -298,7 +300,6 @@ export let weaponAttackMixin = {
             if (weapon.system.rollOnlyDmg) {
                 weapon.rollDamage(damage);
             } else {
-                damage.properties = damage.properties.toObject(false);
                 let messageData = new ChatMessageData(this, messageDataFlavor, 'attack', {
                     attacker: this.uuid,
                     attack: attack,


### PR DESCRIPTION
**Describe the bug**
Fast strike rolls just a single attack instead of two.

To Reproduce
Choose "Fast Strike" as an attack option. The first attack will roll normally, second will fail with an error in the console:
```js
weaponAttackMixin.js:301 Uncaught (in promise) TypeError: damage.properties.toObject is not a function
    at WitcherActor.weaponAttack (weaponAttackMixin.js:301:55)
```


**Expected behavior**
Fast strike rolls two attacks